### PR TITLE
Fixed other players' guns having zero rotation

### DIFF
--- a/public/src/managers/game-manager.js
+++ b/public/src/managers/game-manager.js
@@ -102,13 +102,9 @@ export default class GameManager extends Phaser.Events.EventEmitter {
         Object.values(this.playerList).forEach(/** @type {PlayerModel}*/player => {
             player.update(delta);
 
-            const gun = this.localPlayer.gun;
-            const parentRotation = player.parentContainer?.rotation ?? 0;
-            const radius = 15;
-            gun.x = Math.cos(inputs.aimAngle - parentRotation) * radius;
-            gun.y = Math.sin(inputs.aimAngle - parentRotation) * radius;
-            gun.setRotation(inputs.aimAngle - parentRotation);
-
+            if (player === this.localPlayer) {
+                player.setGunRotation(inputs.aimAngle); // snap if local
+            }
         });
 
         this.refreshInteractables();

--- a/public/src/models/player-model.js
+++ b/public/src/models/player-model.js
@@ -19,7 +19,7 @@ export default class PlayerModel extends Phaser.GameObjects.Container {
         this.scene.add.existing(this);
 
         this.id = id;
-        this.target = { x: 0, y: 0 };
+        this.target = { x: 0, y: 0, aimAngle: 0 };
         this.isSteering = false;
         this.isUsingCannon = false;
         this.aimAngle = 0;
@@ -48,8 +48,20 @@ export default class PlayerModel extends Phaser.GameObjects.Container {
         }
         this.target.x = data.x;
         this.target.y = data.y;
+        this.target.aimAngle = data.aimAngle;
+
+
         this.isSteering = data.isSteering;
         this.isUsingCannon = data.isUsingCannon;
+    }
+
+    setGunRotation(angle) {
+        const gun = this.gun;
+        const parentRotation = this.parentContainer?.rotation | 0;
+
+        gun.x = Math.cos(angle - parentRotation) * 15;  // radius
+        gun.y = Math.sin(angle - parentRotation) * 15;
+        gun.setRotation(angle - parentRotation);
     }
 
     update(delta) {
@@ -58,6 +70,14 @@ export default class PlayerModel extends Phaser.GameObjects.Container {
 
         this.x = Phaser.Math.Linear(this.x, this.target.x, lerp);
         this.y = Phaser.Math.Linear(this.y, this.target.y, lerp);
+
+        this.aimAngle = Phaser.Math.Angle.RotateTo(
+            this.aimAngle,
+            this.target.aimAngle,
+            lerp
+        );
+
+        this.setGunRotation(this.aimAngle);
 
         if (this.parentContainer instanceof ShipModel) {
             const bob = this.parentContainer.hullSprite.y;

--- a/server/src/entities/player.ts
+++ b/server/src/entities/player.ts
@@ -67,6 +67,7 @@ export default class Player extends Entity {
             ...super.serialise(),
             username: this.username,
             isSteering: this.isSteering,
+            aimAngle: this.aimAngle,
             isUsingCannon: this.isUsingCannon
         }
 


### PR DESCRIPTION
Fixed #35

Fixed on the client side, but may present issues later on with the server. The server should carry out linear interpolation between the player's current and new angle (as well as on the client) to ensure that projectiles are created in the "accurate" position relative to the point of view of a different client.