### PR TITLE
Fixed broken sprites

### DIFF
--- a/public/src/models/player-model.js
+++ b/public/src/models/player-model.js
@@ -34,11 +34,10 @@ export default class PlayerModel extends Phaser.GameObjects.Container {
             padding: { x: 6, y: 4 }
         }).setOrigin(0.5, 1).setDepth(100).setPosition(0, -25);
 
-        this.bodySprite = scene.add.sprite(x, y, 'player_circle');
+        this.bodySprite = scene.add.sprite(0, 0, 'player_circle');
         this.add(this.bodySprite);
 
-        this.gun = scene.add.rectangle(15, 0, 15, 5, 0x000000)
-        this.add(this.gun);
+        this.gun = scene.add.rectangle(x + 15, y, 15, 5, 0x000000).setDepth(100);
     }
 
 
@@ -53,15 +52,16 @@ export default class PlayerModel extends Phaser.GameObjects.Container {
 
         this.isSteering = data.isSteering;
         this.isUsingCannon = data.isUsingCannon;
+
     }
 
     setGunRotation(angle) {
-        const gun = this.gun;
-        const parentRotation = this.parentContainer?.rotation | 0;
+        const worldPos = this.getWorldTransformMatrix();
 
-        gun.x = Math.cos(angle - parentRotation) * 15;  // radius
-        gun.y = Math.sin(angle - parentRotation) * 15;
-        gun.setRotation(angle - parentRotation);
+        const gun = this.gun;
+        gun.x = worldPos.tx + Math.cos(angle) * 15;  // radius
+        gun.y = worldPos.ty + Math.sin(angle) * 15;
+        gun.setRotation(angle);
     }
 
     update(delta) {


### PR DESCRIPTION
Fixed broken player sprite- it was being constructed using the absolute coordinates of the player. The player is a container, so this meant it was being constructed at 0,0 relative to the player container, which was several pixels offset from where the player actually was.

Also fixed "wonky" gun physics. Counteracting the ship's rotation is unnecessary; the gun is just added directly to the game scene and rotated there, as with the name text.