### PR TITLE
Fixed bugs with player aiming

### DIFF
--- a/public/src/managers/game-manager.js
+++ b/public/src/managers/game-manager.js
@@ -210,7 +210,6 @@ export default class GameManager extends Phaser.Events.EventEmitter {
 			if (!model) return;
 			this.models.set(data.id, model);
 		}
-
 		// @ts-ignore reparent the player if they left a ship
 		if (data.type === 'player') this.handleReparent(model, data);
 		if (data.type === 'treasure') this.handleTreasureReparent(model, data);
@@ -365,6 +364,7 @@ export default class GameManager extends Phaser.Events.EventEmitter {
 
 		player.setPosition(data.x ?? player.x, data.y ?? player.y);
 		player.parentId = data.parentId ?? null;
+		player.rotation = 0;
 
 		// Snap interpolation targets so movement feels instant on reparent
 		if (data.x !== undefined) player.target.x = data.x;

--- a/public/src/managers/game-manager.js
+++ b/public/src/managers/game-manager.js
@@ -92,8 +92,8 @@ export default class GameManager extends Phaser.Events.EventEmitter {
 		let closest = null;
 		let nearestDist = Infinity;
 		this.models.forEach((entity, id) => {
-			if (entity === this.localPlayer) {
-				entity.target.r = inputs.aimAngle; // shortcut the aim angle for local player
+			if (entity === this.localPlayer && entity instanceof PlayerModel) {
+				this.localPlayer.aimAngle = inputs.aimAngle; // shortcut the aim angle for local player
 			}
 
 			// This replaces the getClosestInteractable function, avoiding another for loop

--- a/public/src/managers/input-manager.js
+++ b/public/src/managers/input-manager.js
@@ -63,13 +63,12 @@ export default class InputManager extends Phaser.Events.EventEmitter {
 	getInputs(scene, player) {
 		/** @type {any} */
 		const keys = this.moveKeys;
-		const cam = scene.cameras.main;
 
-		// Manually convert screen pos to world pos using current camera state
-		const mouseWorldX = scene.input.mousePointer.x / cam.zoom + cam.scrollX;
-		const mouseWorldY = scene.input.mousePointer.y / cam.zoom + cam.scrollY;
-
+		scene.input.mousePointer.updateWorldPoint(scene.cameras.main);
+		const mouseWorldX = scene.input.mousePointer.worldX;
+		const mouseWorldY = scene.input.mousePointer.worldY;
 		const worldPos = player.getWorldTransformMatrix();
+
 		const aimAngle = Math.atan2(mouseWorldY - worldPos.ty, mouseWorldX - worldPos.tx);
 
 		return {

--- a/public/src/models/model.js
+++ b/public/src/models/model.js
@@ -85,7 +85,7 @@ export default class Model extends Phaser.GameObjects.Container {
 		const lerp = 1 - Math.pow(1 - responseFactor, delta / 16.6667); // at 60fps
 		const deltaTime = delta / 1000;
 
-		// Don't move static objects
+		// Don't lerp static objects
 		if (!this.isStatic) {
 			this.interpPosition(deltaTime, lerp);
 			this.interpRotation(deltaTime, lerp);

--- a/public/src/models/player-model.js
+++ b/public/src/models/player-model.js
@@ -111,6 +111,7 @@ export default class PlayerModel extends Model {
 		// Gun is drawn at edge of player sprite
 		gun.setPosition(pos.x + Math.cos(this.aimAngle) * 15, pos.y + Math.sin(this.aimAngle) * 15);
 		gun.setRotation(this.aimAngle);
+		gun.setVisible(!isBusy && !showCarry);
 
 		this.carrySprite.setPosition(Math.cos(this.aimAngle) * 18, Math.sin(this.aimAngle) * 18 + bob);
 
@@ -119,7 +120,6 @@ export default class PlayerModel extends Model {
 		this.nameText.setPosition(pos.x, pos.y - 25);
 		this.respawnIndicator.text.setPosition(pos.x, pos.y);
 
-		this.gun.setVisible(!isBusy && !showCarry);
 		this.carrySprite.setVisible(showCarry);
 		this.setAlpha(isBusy ? 0.6 : 1.0); // visual feedback if using cannon/helm etc
 

--- a/public/src/models/player-model.js
+++ b/public/src/models/player-model.js
@@ -33,7 +33,6 @@ export default class PlayerModel extends Model {
 		this.healthBar = new HealthBar(scene, 40, 20);
 		this.respawnIndicator = new RespawnIndicator(scene, 100, 100);
 
-		// Name text is not a child of the container- avoids counter-rotation logic
 		this.nameText = scene.add
 			.text(0, -50, '', {
 				fontSize: '16px',
@@ -45,10 +44,14 @@ export default class PlayerModel extends Model {
 			.setOrigin(0.5, 1)
 			.setDepth(100)
 			.setPosition(0, -25);
+		this.add(this.nameText);
+
 		this.bodySprite = scene.add.sprite(0, 0, 'player_circle');
 		this.add(this.bodySprite);
 
 		this.gun = scene.add.rectangle(x + 15, y, 15, 5, 0x000000).setDepth(100);
+		this.add(this.gun);
+
 		this.carrySprite = scene.add.sprite(0, -22, 'treasure-chest');
 		this.carrySprite.setDisplaySize(44, 44);
 		this.carrySprite.setDepth(101);
@@ -100,6 +103,10 @@ export default class PlayerModel extends Model {
 		const isBusy = this.isSteering || this.isUsingCannon || this.isDead; // busy dyin'
 		const showCarry = !!this.carryingId;
 
+		if (this.parentContainer) {
+			this.rotation = -this.parentContainer.rotation;
+		}
+
 		let bob = 0; // hi bob
 		if (this.parentContainer instanceof ShipModel) {
 			bob = this.parentContainer.hullSprite.y;
@@ -109,7 +116,7 @@ export default class PlayerModel extends Model {
 		}
 
 		// Gun is drawn at edge of player sprite
-		gun.setPosition(pos.x + Math.cos(this.aimAngle) * 15, pos.y + Math.sin(this.aimAngle) * 15);
+		gun.setPosition(Math.cos(this.aimAngle) * 15, Math.sin(this.aimAngle) * 15);
 		gun.setRotation(this.aimAngle);
 		gun.setVisible(!isBusy && !showCarry);
 
@@ -117,9 +124,7 @@ export default class PlayerModel extends Model {
 
 		// manually update position for non-container objects
 		this.carrySprite.setRotation(this.aimAngle);
-		this.nameText.setPosition(pos.x, pos.y - 25);
 		this.respawnIndicator.text.setPosition(pos.x, pos.y);
-
 		this.carrySprite.setVisible(showCarry);
 		this.setAlpha(isBusy ? 0.6 : 1.0); // visual feedback if using cannon/helm etc
 

--- a/public/src/scenes/index.js
+++ b/public/src/scenes/index.js
@@ -9,14 +9,13 @@ const config = {
 	type: Phaser.AUTO,
 	width: window.innerWidth, // doesn't account for resize yet
 	height: window.innerHeight,
-	roundPixels: false,
 	pixelArt: true,
-	backgroundColor: '#2d80c9',
+	backgroundColor: '#b0e9fc', // same colour as the sea
 	parent: parent,
 	scene: [StartScene, MainScene], // Add all scenes in
 
 	render: {
-		mipmapFilter: 'NEAREST',
+		mipmapFilter: 'LINEAR',
 		antialias: true,
 		premultipliedAlpha: false,
 	},

--- a/public/src/scenes/main-scene.js
+++ b/public/src/scenes/main-scene.js
@@ -70,7 +70,7 @@ export class MainScene extends Phaser.Scene {
 		this.cameraTarget = this.add.circle(0, 0, 5, 0xffffff, 0);
 		const camera = this.cameras.main;
 
-		camera.startFollow(this.cameraTarget);
+		camera.startFollow(this.cameraTarget, true);
 		camera.zoom = this.targetZoom;
 
 		this.inputManager.on('zoom', (deltaY) => {

--- a/server/src/controllers/cannon-controller.ts
+++ b/server/src/controllers/cannon-controller.ts
@@ -13,7 +13,7 @@ export default class CannonController {
 		cannon.targetAngle = data.aimAngle;
 	}
 
-	handleFire(cannon: Cannon): void {
+	handleFire(cannon: Cannon, lastActionTime: number): void {
 		if (!cannon || !cannon.isReloaded) return;
 		cannon.reloadTimer = cannon.reloadTime; // reset the reload timer
 		const ship = cannon.parent as Ship | null;

--- a/server/src/controllers/player-controller.ts
+++ b/server/src/controllers/player-controller.ts
@@ -182,19 +182,32 @@ export default class PlayerController {
 		this.treasureSystem.hit(player);
 	}
 
-	handleGunFire(player: Player) {
+	handleGunFire(player: Player, lastActionTime: number) {
 		// Wait until reloaded
-		if (!player || player.carrying || !player.isReloaded) return;
+		if (!player || player.carrying || !player.isReloaded || player.isSteering) return;
 		player.reloadTimer = player.reloadTime;
+
+		// Calculate time between this event and the last packet
+		const now = Date.now();
+		const latency = (now - lastActionTime) / 1000;
+
 		const worldPos = this.getWorldPosition(player);
 
-		const bullet = new Bullet(`bullet_${Date.now()}_${player.id}`, worldPos.x, worldPos.y, player.aimAngle);
+		// Spawn the bullet at the client's next visual position, not their interp target
+		let spawnX = worldPos.x - player.vx * latency;
+		let spawnY = worldPos.y - player.vy * latency;
+
+		const bullet = new Bullet(`bullet_${Date.now()}_${player.id}`, spawnX, spawnY, player.aimAngle);
 
 		// Apply parent velocity only if on ship
 		if (player.parent && player.parent instanceof Ship) {
 			bullet.vx += player.parent.vx;
 			bullet.vy += player.parent.vy;
 		}
+
+		// catch up to where the bullet should originally have been fired
+		bullet.x += bullet.vx * latency;
+		bullet.y += bullet.vy * latency;
 
 		bullet.firedBy = player;
 		this.entityRegistry.create(bullet);

--- a/server/src/controllers/player-controller.ts
+++ b/server/src/controllers/player-controller.ts
@@ -195,6 +195,7 @@ export default class PlayerController {
 		const bullet = new Bullet(`bullet_${Date.now()}_${player.id}`, worldPos.x, worldPos.y, player.aimAngle);
 		bullet.vx += player.vx;
 		bullet.vy += player.vy;
+
 		bullet.firedBy = player;
 
 		// Add to the entity registry

--- a/server/src/controllers/player-controller.ts
+++ b/server/src/controllers/player-controller.ts
@@ -185,20 +185,18 @@ export default class PlayerController {
 	handleGunFire(player: Player) {
 		// Wait until reloaded
 		if (!player || player.carrying || !player.isReloaded) return;
-
-		// Reset reload timer
 		player.reloadTimer = player.reloadTime;
-
-		// Get player world pos
 		const worldPos = this.getWorldPosition(player);
 
 		const bullet = new Bullet(`bullet_${Date.now()}_${player.id}`, worldPos.x, worldPos.y, player.aimAngle);
-		bullet.vx += player.vx;
-		bullet.vy += player.vy;
+
+		// Apply parent velocity only if on ship
+		if (player.parent && player.parent instanceof Ship) {
+			bullet.vx += player.parent.vx;
+			bullet.vy += player.parent.vy;
+		}
 
 		bullet.firedBy = player;
-
-		// Add to the entity registry
 		this.entityRegistry.create(bullet);
 	}
 

--- a/server/src/controllers/world-controller.ts
+++ b/server/src/controllers/world-controller.ts
@@ -28,6 +28,8 @@ export default class WorldController {
 	messageController: MessageController;
 	cannonController: CannonController;
 
+	timestamps: Map<string, number> = new Map();
+
 	/**
 	 * Constructs a WorldController with the provided sub-controllers
 	 * @param entityRegistry to reference the entities in the game
@@ -50,6 +52,9 @@ export default class WorldController {
 	 * @param action the action, matching the schema PlayerAction, sent by the user
 	 */
 	public handle(playerId: string, action: PlayerAction) {
+		// keep track of the time the player last sent an action
+		const lastActionTime = this.timestamps.get(playerId) || Date.now(); // if not seen before
+
 		const player = this.entityRegistry.get<Player>(playerId);
 		if (!player) return;
 
@@ -81,6 +86,8 @@ export default class WorldController {
 		switch (action.type) {
 			// Send move inputs based on player context
 			case ActionType.MOVE:
+				this.timestamps.set(playerId, Date.now()); // overwrite
+
 				if (player.cannon) {
 					this.cannonController.handleMove(player.cannon, action.data);
 
@@ -105,10 +112,10 @@ export default class WorldController {
 				}
 
 				if (player.cannon) {
-					this.cannonController.handleFire(player.cannon);
+					this.cannonController.handleFire(player.cannon, lastActionTime);
 				} else {
 					// If not controlling a cannon, fire the player's personal gun
-					this.playerController.handleGunFire(player);
+					this.playerController.handleGunFire(player, lastActionTime);
 				}
 				break;
 			case ActionType.INTERACT:

--- a/server/src/entities/player.ts
+++ b/server/src/entities/player.ts
@@ -24,7 +24,7 @@ export default class Player extends Entity {
 		right: boolean;
 	};
 	aimAngle: number;
-	reloadTime: number = 1000;
+	reloadTime: number = 10;
 	reloadTimer: number = 0;
 	activeMinigame: Minigame | null = null;
 

--- a/server/src/entities/player.ts
+++ b/server/src/entities/player.ts
@@ -24,7 +24,7 @@ export default class Player extends Entity {
 		right: boolean;
 	};
 	aimAngle: number;
-	reloadTime: number = 10;
+	reloadTime: number = 500;
 	reloadTimer: number = 0;
 	activeMinigame: Minigame | null = null;
 

--- a/server/src/entities/projectiles/projectile.ts
+++ b/server/src/entities/projectiles/projectile.ts
@@ -18,4 +18,11 @@ export default class Projectile extends Entity {
 		this.vx = Math.cos(r) * speed;
 		this.vy = Math.sin(r) * speed; // calculate velocity from speed scalar
 	}
+
+	toState() {
+		return {
+			...super.toState(),
+			firedBy: this.firedBy ? this.firedBy.id : null,
+		};
+	}
 }

--- a/server/src/systems/movement-system.ts
+++ b/server/src/systems/movement-system.ts
@@ -51,6 +51,21 @@ export default class MovementSystem implements BaseSystem {
 		npcs.forEach((npc) => this.updateNPC(npc, dt));
 	}
 
+	updateReloadTimer(player: Player, dt: number) {
+		if (player.reloadTimer > 0) {
+			player.reloadTimer = Math.max(0, player.reloadTimer - dt * 1000);
+			player.markDirty();
+		}
+	}
+
+	updateRespawnTimer(player: Player, dt: number) {
+		// move to own system
+		if (player.respawnTimer > 0 && player.respawnStarted) {
+			player.respawnTimer = Math.max(0, player.respawnTimer - dt * 1000);
+			player.markDirty();
+		}
+	}
+
 	/**
 	 * Applies movement for a given player, accounting for on-ship conditions,
 	 * different movement speed for on-land vs in-sea, collision with inner/outer
@@ -59,19 +74,12 @@ export default class MovementSystem implements BaseSystem {
 	 * @param dt the difference in time from the last update
 	 */
 	updatePlayer(player: Player, dt: number, ships: Ship[]): void {
-		if (player.reloadTimer > 0) {
-			player.reloadTimer = Math.max(0, player.reloadTimer - dt * 1000);
-			player.markDirty();
-		}
-
-		// move to own system
-		if (player.respawnTimer > 0 && player.respawnStarted) {
-			player.respawnTimer = Math.max(0, player.respawnTimer - dt * 1000);
-			player.markDirty();
-		}
+		this.updateReloadTimer(player, dt);
+		this.updateRespawnTimer(player, dt);
 
 		// Keep track of aim angle- don't send for static players
 		const prevAimAngle = (player as any).prevAimAngle ?? player.aimAngle;
+
 		if (Math.abs(player.aimAngle - prevAimAngle) > 0.01) {
 			player.markDirty();
 		}
@@ -111,14 +119,16 @@ export default class MovementSystem implements BaseSystem {
 		if (left) dx -= 1;
 		if (right) dx += 1;
 
-		const aimChanged = Math.abs(player.aimAngle - prevAimAngle) > 0.01;
-		(player as any).prevAimAngle = player.aimAngle;
-
 		const prevX = player.x; // to calculate velocity difference for client-side extrapolation
 		const prevY = player.y;
 
 		// If no inputs, do nothing
-		if (dx === 0 && dy === 0) return;
+		if (dx === 0 && dy === 0) {
+			// reset velocity
+			player.vx = 0;
+			player.vy = 0;
+			return;
+		}
 
 		// Normalize diagonal movement- players move the same speed in all directions
 		const length = Math.sqrt(dx * dx + dy * dy);
@@ -193,9 +203,10 @@ export default class MovementSystem implements BaseSystem {
 		player.vx = (player.x - prevX) / dt;
 		player.vy = (player.y - prevY) / dt;
 
+		console.log(player.vx, player.vy, player.x, player.y, prevX, prevY);
+
 		// Mark dirty if position changed enough
-		const moved =
-			Math.abs(player.x - prevX) > POS_THRESHOLD || Math.abs(player.y - prevY) > POS_THRESHOLD || aimChanged;
+		const moved = Math.abs(player.x - prevX) > POS_THRESHOLD || Math.abs(player.y - prevY) > POS_THRESHOLD;
 
 		if (moved) player.markDirty();
 	}

--- a/server/src/systems/movement-system.ts
+++ b/server/src/systems/movement-system.ts
@@ -292,6 +292,23 @@ export default class MovementSystem implements BaseSystem {
 		};
 
 		Body.applyForce(body, body.position, force);
+
+		// update entity from physics body
+		const prevR = ship.r;
+		const prevX = ship.x;
+		const prevY = ship.y;
+
+		ship.x = body.position.x;
+		ship.y = body.position.y;
+		ship.r = body.angle;
+
+		// sent in delta if changed substantially
+		const rotationChanged = Math.abs(ship.r - prevR) > 0.001;
+		const positionChanged = Math.abs(ship.x - prevX) > 0.1 || Math.abs(ship.y - prevY) > 0.1;
+
+		if (rotationChanged || positionChanged) {
+			ship.markDirty();
+		}
 	}
 
 	updateCannon(cannon: Cannon, dt: number) {

--- a/server/src/systems/movement-system.ts
+++ b/server/src/systems/movement-system.ts
@@ -203,8 +203,6 @@ export default class MovementSystem implements BaseSystem {
 		player.vx = (player.x - prevX) / dt;
 		player.vy = (player.y - prevY) / dt;
 
-		console.log(player.vx, player.vy, player.x, player.y, prevX, prevY);
-
 		// Mark dirty if position changed enough
 		const moved = Math.abs(player.x - prevX) > POS_THRESHOLD || Math.abs(player.y - prevY) > POS_THRESHOLD;
 


### PR DESCRIPTION
Fixes #90 
Fixes #78 
Fixes #74 

Fixed a bug where the player's aim angle was being calculated from a stale mouse position. When the player stopped moving their mouse but continued to move the player, the mouse position never updated. Also changed projectiles to only inherit parent physics body velocity, not players- this was causing weird stuff to happen.

Also fixed a similar rotation bug with players. Name tags and guns were not added to containers to avoid having to counter-rotate, but it turns out this was really easy. Now the gun/name tag don't lag behind players.

Re-enabled syncing ships' matter bodies to their entities, and players can no longer fire a gun while using a cannon. 