### PR TITLE
Simplified Ship / Cannon Movement

### DIFF
--- a/public/src/models/interactable-model.js
+++ b/public/src/models/interactable-model.js
@@ -20,8 +20,8 @@ export default class InteractableModel extends Model {
 	 */
 	constructor(scene, parent, id, type, x, y, texture = '', usePrompt = '', releasePrompt = '') {
 		super(scene, id, x, y, type, 0, true); // is static
-		this.isInteractable = true;
 		this.type = type;
+		this.isInteractable = true;
 		this.usePrompt = usePrompt || `Use ${this.type}`;
 		this.releasePrompt = releasePrompt || '';
 		this.textureKey = texture || 'interactable'; // default

--- a/public/src/models/model.js
+++ b/public/src/models/model.js
@@ -158,7 +158,7 @@ export default class Model extends Phaser.GameObjects.Container {
 	 * excessive getWorldTransformMatrix() calls.
 	 */
 	get worldPos() {
-		if (this.scene.game) {
+		if (this.scene && this.scene.game) {
 			const currentFrame = this.scene.game.loop.frame;
 			if (this.#cachedFrame === currentFrame) {
 				return this.#worldPos;

--- a/server/src/controllers/cannon-controller.ts
+++ b/server/src/controllers/cannon-controller.ts
@@ -16,8 +16,6 @@ export default class CannonController {
 	}
 
 	handleFire(cannon: Cannon, lastActionTime: number): void {
-		if (!cannon || !cannon.isReloaded) return;
-		cannon.reloadTimer = cannon.reloadTime; // reset the reload timer
 		const ship = cannon.parent as Ship | null;
 
 		this.combatHandler.handleCannonFire(cannon, ship);

--- a/server/src/controllers/cannon-controller.ts
+++ b/server/src/controllers/cannon-controller.ts
@@ -1,12 +1,14 @@
 import Cannon from '../entities/interactables/cannon';
 import EntityRegistry from '../engine/entity-registry';
 import { MoveData } from '@shared/socket-protocol';
-import Entity from '../entities/entity';
 import Ship from '../entities/ship';
-import Cannonball from '../entities/projectiles/cannonball';
+import CombatHandler from '../handlers/combat-handler';
 
 export default class CannonController {
-	constructor(private entityRegistry: EntityRegistry) {}
+	constructor(
+		private entityRegistry: EntityRegistry,
+		private combatHandler: CombatHandler
+	) {}
 
 	handleMove(cannon: Cannon, data: MoveData): void {
 		if (!cannon) return;
@@ -18,51 +20,6 @@ export default class CannonController {
 		cannon.reloadTimer = cannon.reloadTime; // reset the reload timer
 		const ship = cannon.parent as Ship | null;
 
-		const cannonEndOffset = 20; // distance from the center of the cannon to the tip
-		const worldAngle = ship ? cannon.r + ship.r : cannon.r;
-
-		const worldPos = this.getWorldPosition(cannon);
-		const spawnPos = {
-			x: worldPos.x + Math.cos(worldAngle) * cannonEndOffset,
-			y: worldPos.y + Math.sin(worldAngle) * cannonEndOffset,
-		};
-
-		const worldVel = ship ? { x: ship.vx, y: ship.vx } : { x: 0, y: 0 };
-		const ball = new Cannonball(
-			`cannonball_${Date.now()}`,
-			spawnPos.x,
-			spawnPos.y,
-			worldAngle,
-			cannon.cannonballSpeed,
-			cannon.cannonDamage
-		);
-		ball.vx += worldVel.x;
-		ball.vy += worldVel.y;
-		ball.firedBy = cannon; // avoid hitting own ship
-		ball.damage = cannon.cannonDamage;
-		this.entityRegistry.create(ball);
-	}
-
-	/**
-	 * Helper method to get the absolute coordinates of an entity if they are on a ship.
-	 * @param entity the entity for which to find the absolute coordinates
-	 * @returns
-	 */
-	private getWorldPosition(entity: Entity) {
-		if (!entity.parent) {
-			// If the entity has no parent, its coordinates are already in world space
-			return { x: entity.x, y: entity.y };
-		}
-
-		const parent = this.entityRegistry.get<Ship>(entity.parent.id);
-
-		// If the parent is a ship, use its localToWorld method
-		if (parent) {
-			const ship = parent as Ship;
-			return ship.localToWorld(entity.x, entity.y);
-		}
-
-		// If the parent is not a ship, return the entity's local position
-		return { x: entity.x, y: entity.y };
+		this.combatHandler.handleCannonFire(cannon, ship);
 	}
 }

--- a/server/src/controllers/player-controller.ts
+++ b/server/src/controllers/player-controller.ts
@@ -68,8 +68,6 @@ export default class PlayerController {
 		// Distance between player and interactable
 		const canInteract = interactable.canInteract(player);
 
-		console.log(canInteract, interactable.type);
-
 		if (canInteract) {
 			const ship = interactable.parent as Ship;
 

--- a/server/src/controllers/player-controller.ts
+++ b/server/src/controllers/player-controller.ts
@@ -66,12 +66,9 @@ export default class PlayerController {
 		}
 
 		// Distance between player and interactable
-		const dist = Math.sqrt(
-			Math.pow(playerWorldPos.x - interactableWorldPos?.x, 2) +
-				Math.pow(playerWorldPos.y - interactableWorldPos?.y, 2)
-		);
+		const canInteract = interactable.canInteract(player);
 
-		if (dist < 50) {
+		if (canInteract) {
 			const ship = interactable.parent as Ship;
 
 			switch (interactable.type) {
@@ -80,8 +77,10 @@ export default class PlayerController {
 					break;
 
 				case 'cannon':
+					// only if off-ship
 					this.interactionHandler.handleCannonInteraction(player, interactable as Cannon);
 					break;
+
 				case 'ladder':
 					this.interactionHandler.handleLadderInteraction(player, ship, interactable as Ladder);
 					break;

--- a/server/src/controllers/player-controller.ts
+++ b/server/src/controllers/player-controller.ts
@@ -68,6 +68,8 @@ export default class PlayerController {
 		// Distance between player and interactable
 		const canInteract = interactable.canInteract(player);
 
+		console.log(canInteract, interactable.type);
+
 		if (canInteract) {
 			const ship = interactable.parent as Ship;
 

--- a/server/src/controllers/ship-controller.ts
+++ b/server/src/controllers/ship-controller.ts
@@ -2,7 +2,7 @@ import CombatHandler from '../handlers/combat-handler';
 import EntityRegistry from '../engine/entity-registry';
 import Ship from '../entities/ship';
 import { MoveData } from '@shared/socket-protocol';
-import Cannon from 'src/entities/interactables/cannon';
+import Cannon from '../entities/interactables/cannon';
 
 /**
  * Handles ship events

--- a/server/src/controllers/ship-controller.ts
+++ b/server/src/controllers/ship-controller.ts
@@ -34,10 +34,10 @@ export default class ShipController {
 	handleFire(ship: Ship) {
 		const cannons = ship.interactables.filter((item) => item.type === 'cannon');
 
-		cannons.forEach((cannon) => {
+		cannons.forEach((cannon, index) => {
 			if (!(cannon instanceof Cannon)) return;
 
-			this.combatHandler.handleCannonFire(cannon, ship);
+			this.combatHandler.handleCannonFire(cannon, ship, index);
 		});
 	}
 }

--- a/server/src/controllers/ship-controller.ts
+++ b/server/src/controllers/ship-controller.ts
@@ -1,12 +1,17 @@
+import CombatHandler from '../handlers/combat-handler';
 import EntityRegistry from '../engine/entity-registry';
 import Ship from '../entities/ship';
 import { MoveData } from '@shared/socket-protocol';
+import Cannon from 'src/entities/interactables/cannon';
 
 /**
  * Handles ship events
  */
 export default class ShipController {
-	constructor(entityRegistry: EntityRegistry) {}
+	constructor(
+		private entityRegistry: EntityRegistry,
+		private combatHandler: CombatHandler
+	) {}
 
 	/**
 	 * Provides movement inputs to the specified ship. Note that this method will only
@@ -16,27 +21,23 @@ export default class ShipController {
 	 * @param data the movement data to provide to the ship
 	 */
 	handleMove(ship: Ship, data: MoveData): void {
-		// Accel/decel
-		if (data.up) {
-			ship.sailState += 0.03;
-		} else if (data.down) {
-			ship.sailState -= 0.05;
-		}
-		// Steer ship
-		if (data.left) {
-			ship.turnAngle -= 0.03;
-		} else if (data.right) {
-			ship.turnAngle += 0.03;
-		}
+		ship.inputs.up = data.up;
+		ship.inputs.down = data.down;
+		ship.inputs.left = data.left;
+		ship.inputs.right = data.right;
+	}
 
-		// Turning deadzone
-		if (ship.body.isSleeping) {
-			ship.turnAngle = 0; // don't keep spinning
-		}
+	/**
+	 * Fires all the cannons on this ship
+	 * @param ship
+	 */
+	handleFire(ship: Ship) {
+		const cannons = ship.interactables.filter((item) => item.type === 'cannon');
 
-		// Avoid weird division
-		if (-0.001 < ship.turnAngle && ship.turnAngle < 0.001) {
-			ship.turnAngle = 0;
-		}
+		cannons.forEach((cannon) => {
+			if (!(cannon instanceof Cannon)) return;
+
+			this.combatHandler.handleCannonFire(cannon, ship);
+		});
 	}
 }

--- a/server/src/controllers/world-controller.ts
+++ b/server/src/controllers/world-controller.ts
@@ -83,6 +83,7 @@ export default class WorldController {
 			return; // don't handle actions if dead, just respawn
 		}
 
+		const ship = player.parent as Ship;
 		switch (action.type) {
 			// Send move inputs based on player context
 			case ActionType.MOVE:
@@ -93,8 +94,6 @@ export default class WorldController {
 
 					// If player is at the helm, move the ship
 				} else if (player.parent && player.isSteering) {
-					const ship = player.parent as Ship;
-
 					this.shipController.handleMove(ship, action.data);
 				} else {
 					// Otherwise move the player
@@ -109,10 +108,10 @@ export default class WorldController {
 			case ActionType.FIRE:
 				if (player.isDigging) {
 					this.playerController.handleDig(player);
-				}
-
-				if (player.cannon) {
+				} else if (player.cannon) {
 					this.cannonController.handleFire(player.cannon, lastActionTime);
+				} else if (player.isSteering) {
+					this.shipController.handleFire(ship);
 				} else {
 					// If not controlling a cannon, fire the player's personal gun
 					this.playerController.handleGunFire(player, lastActionTime);

--- a/server/src/entities/entity-factory.ts
+++ b/server/src/entities/entity-factory.ts
@@ -138,9 +138,10 @@ export default class EntityFactory {
 		speed: number,
 		damage: number,
 		parentV: { x: number; y: number },
-		origin: Cannon
+		origin: Cannon,
+		index: number // so each cannonball doesn't have the same ID
 	): Cannonball {
-		const ball = new Cannonball(`cannonball_${Date.now()}`, x, y, r, speed, damage);
+		const ball = new Cannonball(`cannonball_${Date.now()}_${index}`, x, y, r, speed, damage);
 
 		ball.vx += parentV.x;
 		ball.vy += parentV.y;

--- a/server/src/entities/entity-factory.ts
+++ b/server/src/entities/entity-factory.ts
@@ -12,6 +12,7 @@ import NPC from './npcs/npc';
 import NPCShip from './npcs/npc-ship';
 import Treasure from './interactables/treasure';
 import Money from './interactables/money';
+import Cannonball from './projectiles/cannonball';
 
 /**
  * Aggregates entity creation, applying domain-specific default values from
@@ -128,5 +129,24 @@ export default class EntityFactory {
 			this.createInteractable(npcShip, item, index);
 		});
 		return npcShip;
+	}
+
+	public createCannonball(
+		x: number,
+		y: number,
+		r: number,
+		speed: number,
+		damage: number,
+		parentV: { x: number; y: number },
+		origin: Cannon
+	): Cannonball {
+		const ball = new Cannonball(`cannonball_${Date.now()}`, x, y, r, speed, damage);
+
+		ball.vx += parentV.x;
+		ball.vy += parentV.y;
+		ball.firedBy = origin;
+
+		this.entityRegistry.create(ball);
+		return ball;
 	}
 }

--- a/server/src/entities/entity.ts
+++ b/server/src/entities/entity.ts
@@ -161,9 +161,11 @@ export default abstract class Entity {
 			const rotatedX = this.x * cos - this.y * sin;
 			const rotatedY = this.x * sin + this.y * cos;
 
+			const parentPos = parent.worldPos; // cheeky bit of recursion
+
 			return {
-				x: this.x + rotatedX,
-				y: this.y + rotatedY,
+				x: parentPos.x + rotatedX,
+				y: parentPos.y + rotatedY,
 			};
 		} else {
 			return { x: this.x, y: this.y };

--- a/server/src/entities/entity.ts
+++ b/server/src/entities/entity.ts
@@ -147,4 +147,26 @@ export default abstract class Entity {
 		}
 		return null;
 	}
+
+	/**
+	 * Returns the absolute x and y coordinates of this entity. Translates coordinates
+	 * to world space if a parent exists, otherwise returns x and y.
+	 */
+	public get worldPos(): { x: number; y: number } {
+		if (this.parent) {
+			const parent = this.parent;
+			const cos = Math.cos(parent.r);
+			const sin = Math.sin(parent.r);
+
+			const rotatedX = this.x * cos - this.y * sin;
+			const rotatedY = this.x * sin + this.y * cos;
+
+			return {
+				x: this.x + rotatedX,
+				y: this.y + rotatedY,
+			};
+		} else {
+			return { x: this.x, y: this.y };
+		}
+	}
 }

--- a/server/src/entities/interactables/interactable.ts
+++ b/server/src/entities/interactables/interactable.ts
@@ -15,10 +15,8 @@ export default class Interactable extends Entity {
 	}
 
 	public canInteract(player: Player) {
-		if (player.parent !== this.parent) return; // must be on same body
-
-		const dx = this.x - player.x;
-		const dy = this.y - player.y;
+		const dx = this.worldPos.x - player.worldPos.x;
+		const dy = this.worldPos.y - player.worldPos.y;
 
 		return Math.sqrt(dx * dx + dy * dy) <= this.interactRange;
 	}

--- a/server/src/entities/ship.ts
+++ b/server/src/entities/ship.ts
@@ -16,9 +16,7 @@ export default class Ship extends Entity {
 	physics: ShipConfig['physics'];
 	interactables: Interactable[];
 	body: Matter.Body;
-	anchored: boolean;
 	private _turnAngle: number = 0;
-	private _sailState: number = 0; // not moving
 
 	private upgradeConfig: UpgradeConfig;
 	public upgrades: Record<string, number> = {
@@ -30,6 +28,13 @@ export default class Ship extends Entity {
 		maxHealth: 1,
 	};
 	sunkNotified: boolean = false;
+
+	public inputs = {
+		up: false,
+		down: false,
+		left: false,
+		right: false,
+	};
 
 	/**
 	 * Creates a ship with the provided data
@@ -53,7 +58,6 @@ export default class Ship extends Entity {
 		this.dimensions = config.dimensions;
 		this.physics = config.physics;
 		this.interactables = [];
-		this.anchored = true; // anchored at startup
 
 		// For adding to the matter-js world
 		this.body = this.createPhysicsBody(x, y);
@@ -86,8 +90,6 @@ export default class Ship extends Entity {
 		return {
 			...super.toState(),
 			pilotId: this.pilot?.id, // For client side messages
-			sailState: this.sailState,
-			anchored: this.anchored,
 			upgrades: this.upgrades,
 			turnAngle: this.turnAngle,
 		};
@@ -99,14 +101,6 @@ export default class Ship extends Entity {
 
 	public get turnAngle() {
 		return this._turnAngle;
-	}
-
-	public set sailState(newSail: number) {
-		this._sailState = Math.max(Math.min(1, newSail), 0);
-	}
-
-	public get sailState() {
-		return this._sailState;
 	}
 
 	public get acceleration() {

--- a/server/src/entities/ship.ts
+++ b/server/src/entities/ship.ts
@@ -16,7 +16,6 @@ export default class Ship extends Entity {
 	physics: ShipConfig['physics'];
 	interactables: Interactable[];
 	body: Matter.Body;
-	private _turnAngle: number = 0;
 
 	private upgradeConfig: UpgradeConfig;
 	public upgrades: Record<string, number> = {
@@ -91,16 +90,7 @@ export default class Ship extends Entity {
 			...super.toState(),
 			pilotId: this.pilot?.id, // For client side messages
 			upgrades: this.upgrades,
-			turnAngle: this.turnAngle,
 		};
-	}
-
-	public set turnAngle(newAngle: number) {
-		this._turnAngle = Math.min(Math.max(-1, newAngle), 1);
-	}
-
-	public get turnAngle() {
-		return this._turnAngle;
 	}
 
 	public get acceleration() {

--- a/server/src/handlers/combat-handler.ts
+++ b/server/src/handlers/combat-handler.ts
@@ -1,0 +1,32 @@
+import EntityFactory from 'src/entities/entity-factory';
+import Cannon from 'src/entities/interactables/cannon';
+import Ship from 'src/entities/ship';
+
+export default class CombatHandler {
+	constructor(private factory: EntityFactory) {}
+
+	handleCannonFire(cannon: Cannon, ship: Ship | null = null) {
+		if (!cannon || !cannon.isReloaded) return;
+
+		cannon.reloadTimer = cannon.reloadTime;
+		const cannonEndOffset = 20;
+		const worldAngle = ship ? cannon.r + ship.r : cannon.r;
+
+		const worldPos = cannon.worldPos;
+		const spawnPos = {
+			x: worldPos.x + Math.cos(worldAngle) * cannonEndOffset,
+			y: worldPos.y + Math.sin(worldAngle) * cannonEndOffset,
+		};
+
+		const worldVel = ship ? { x: ship.vx, y: ship.vx } : { x: 0, y: 0 };
+		this.factory.createCannonball(
+			spawnPos.x,
+			spawnPos.y,
+			worldAngle,
+			cannon.cannonballSpeed,
+			cannon.cannonDamage,
+			worldVel,
+			cannon
+		);
+	}
+}

--- a/server/src/handlers/combat-handler.ts
+++ b/server/src/handlers/combat-handler.ts
@@ -1,11 +1,11 @@
-import EntityFactory from 'src/entities/entity-factory';
-import Cannon from 'src/entities/interactables/cannon';
-import Ship from 'src/entities/ship';
+import EntityFactory from '../entities/entity-factory';
+import Cannon from '../entities/interactables/cannon';
+import Ship from '../entities/ship';
 
 export default class CombatHandler {
 	constructor(private factory: EntityFactory) {}
 
-	handleCannonFire(cannon: Cannon, ship: Ship | null = null) {
+	handleCannonFire(cannon: Cannon, ship: Ship | null = null, index: number = 0) {
 		if (!cannon || !cannon.isReloaded) return;
 
 		cannon.reloadTimer = cannon.reloadTime;
@@ -19,17 +19,17 @@ export default class CombatHandler {
 		};
 
 		const worldVel = ship ? { x: ship.vx, y: ship.vy } : { x: 0, y: 0 };
-		const cannonball = this.factory.createCannonball(
+		const ball = this.factory.createCannonball(
 			spawnPos.x,
 			spawnPos.y,
 			worldAngle,
 			cannon.cannonballSpeed,
 			cannon.cannonDamage,
 			worldVel,
-			cannon
+			cannon,
+			index
 		);
-		cannonball.markDirty();
 
-		console.log(cannonball.x, cannonball.y, worldAngle, worldVel);
+		ball.markDirty();
 	}
 }

--- a/server/src/handlers/combat-handler.ts
+++ b/server/src/handlers/combat-handler.ts
@@ -18,8 +18,8 @@ export default class CombatHandler {
 			y: worldPos.y + Math.sin(worldAngle) * cannonEndOffset,
 		};
 
-		const worldVel = ship ? { x: ship.vx, y: ship.vx } : { x: 0, y: 0 };
-		this.factory.createCannonball(
+		const worldVel = ship ? { x: ship.vx, y: ship.vy } : { x: 0, y: 0 };
+		const cannonball = this.factory.createCannonball(
 			spawnPos.x,
 			spawnPos.y,
 			worldAngle,
@@ -28,5 +28,8 @@ export default class CombatHandler {
 			worldVel,
 			cannon
 		);
+		cannonball.markDirty();
+
+		console.log(cannonball.x, cannonball.y, worldAngle, worldVel);
 	}
 }

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -35,6 +35,7 @@ import SpawnSystem from './systems/spawn-system';
 import SessionHandler from './handlers/session-handler';
 import Player from './entities/player';
 import UpgradeHandler from './handlers/upgrade-handler';
+import CombatHandler from './handlers/combat-handler';
 
 // Create the express app & server
 const app = express();
@@ -90,6 +91,7 @@ const sessionHandler = new SessionHandler(
 	removePhysicsBody,
 	onEntityRemoved
 );
+const combatHandler = new CombatHandler(entityFactory);
 
 const worldController = new WorldController(registry, sessionHandler, {
 	playerController: new PlayerController(
@@ -100,9 +102,9 @@ const worldController = new WorldController(registry, sessionHandler, {
 		treasureSystem,
 		spawnSystem
 	),
-	shipController: new ShipController(registry),
+	shipController: new ShipController(registry, combatHandler),
 	messageController: new MessageController(),
-	cannonController: new CannonController(registry),
+	cannonController: new CannonController(registry, combatHandler),
 });
 
 const gameWorld = new GameWorld(

--- a/server/src/systems/movement-system.ts
+++ b/server/src/systems/movement-system.ts
@@ -318,23 +318,34 @@ export default class MovementSystem implements BaseSystem {
 			cannon.markDirty();
 		}
 
-		if (!cannon.user) return;
-
 		const ship = cannon.parent as Ship | null;
+		const facingAngle = cannon.y < 0 ? -Math.PI / 2 : Math.PI / 2; // start angle
+		let localTarget: number; // where to aim towards
 
-		let localTarget = ship ? cannon.targetAngle - ship.r : cannon.targetAngle;
-		while (localTarget > Math.PI) localTarget -= 2 * Math.PI;
-		while (localTarget < -Math.PI) localTarget += 2 * Math.PI;
+		if (!cannon.user) {
+			localTarget = facingAngle;
+		} else {
+			localTarget = ship ? cannon.targetAngle - ship.r : cannon.targetAngle;
 
-		const facingAngle = cannon.y < 0 ? -Math.PI / 2 : Math.PI / 2;
-		const clampedTarget = Math.max(facingAngle - CANNON_ARC, Math.min(facingAngle + CANNON_ARC, localTarget));
+			while (localTarget > Math.PI) localTarget -= 2 * Math.PI;
+			while (localTarget < -Math.PI) localTarget += 2 * Math.PI;
 
-		let diff = clampedTarget - cannon.r;
+			// clamp to aim cone
+			localTarget = Math.max(facingAngle - CANNON_ARC, Math.min(facingAngle + CANNON_ARC, localTarget));
+		}
+
+		// move towards whatever target
+		let diff = localTarget - cannon.r;
 		while (diff > Math.PI) diff -= 2 * Math.PI;
 		while (diff < -Math.PI) diff += 2 * Math.PI;
 
 		const maxStep = MAX_CANNON_SPEED * dt;
-		cannon.r += Math.max(-maxStep, Math.min(maxStep, diff));
+
+		// only update if sizable difference
+		if (Math.abs(diff) > 0.001) {
+			cannon.r += Math.max(-maxStep, Math.min(maxStep, diff));
+			cannon.markDirty();
+		}
 	}
 
 	updateNPC(npc: NPC, dt: number) {

--- a/server/src/systems/movement-system.ts
+++ b/server/src/systems/movement-system.ts
@@ -294,36 +294,21 @@ export default class MovementSystem implements BaseSystem {
 	 */
 	updateShip(ship: Ship, dt: number) {
 		const body = ship.body;
-		const sailState = ship.sailState;
-		const turnAngle = ship.turnAngle;
 		const acceleration = ship.acceleration; // using get method for auto-applied modifier
+		const { up, left, right } = ship.inputs;
 		const { turnSpeed } = ship.physics;
 
 		// Turning
-		Body.setAngularVelocity(body, turnSpeed * turnAngle);
+		if (right) Body.setAngularVelocity(body, turnSpeed);
+		if (left) Body.setAngularVelocity(body, -turnSpeed);
 
-		const force = {
-			x: Math.cos(body.angle) * acceleration * sailState,
-			y: Math.sin(body.angle) * acceleration * sailState,
-		};
+		if (up) {
+			const force = {
+				x: Math.cos(body.angle) * acceleration,
+				y: Math.sin(body.angle) * acceleration,
+			};
 
-		Body.applyForce(body, body.position, force);
-
-		// update entity from physics body
-		const prevR = ship.r;
-		const prevX = ship.x;
-		const prevY = ship.y;
-
-		ship.x = body.position.x;
-		ship.y = body.position.y;
-		ship.r = body.angle;
-
-		// sent in delta if changed substantially
-		const rotationChanged = Math.abs(ship.r - prevR) > 0.001;
-		const positionChanged = Math.abs(ship.x - prevX) > 0.1 || Math.abs(ship.y - prevY) > 0.1;
-
-		if (rotationChanged || positionChanged) {
-			ship.markDirty();
+			Body.applyForce(body, body.position, force);
 		}
 	}
 

--- a/server/src/systems/npc-system.ts
+++ b/server/src/systems/npc-system.ts
@@ -115,7 +115,7 @@ export default class NPCSystem implements BaseSystem {
 				npc.id
 			) as Money;
 
-			money.value = Math.floor(Math.random() * 100) + 50; // avoid floating point money
+			money.value = Math.floor(Math.random() * 100) + (npc instanceof NPCShip ? 5000 : 50); // avoid floating point money
 		}
 	}
 


### PR DESCRIPTION
Controlling cannons independently of ships was really annoying after a while, and so was the continuous movement/turning. Ships now move in arcade-style and can fire all cannons simultaneously by pressing space.

