### PR TITLE
Fixed physics breaking on ship respawn

### DIFF
--- a/server/src/controllers/player-controller.ts
+++ b/server/src/controllers/player-controller.ts
@@ -139,21 +139,18 @@ export default class PlayerController {
 
 	handleRespawnShip(player: Player): void {
 		// Respawn ship & player at a new location
-		// TODO: Ensure player is a set distance from their death point
-
 		const ship = player.ship;
 		const { x, y } = this.spawnSystem.getSpawnPoint();
 
-		ship.body.position.x = x;
-		ship.body.position.y = y;
+		// Everything must be reset through matter to change properly
+		Matter.Body.setPosition(ship.body, { x, y });
+		Matter.Body.setVelocity(ship.body, { x: 0, y: 0 });
+		Matter.Body.setAngle(ship.body, 0);
+		Matter.Body.setAngularVelocity(ship.body, 0);
+
 		ship.x = x;
 		ship.y = y;
 		ship.health = ship.maxHealth;
-
-		// velocity has to be set like this
-		// ship.vx is mirrored directly from the physics body
-		const vec = Matter.Vector.create(0, 0);
-		Matter.Body.setVelocity(ship.body, vec);
 
 		// tell client to skip extrapolation
 		ship.pendingTeleport = true;

--- a/server/src/systems/movement-system.ts
+++ b/server/src/systems/movement-system.ts
@@ -475,7 +475,7 @@ export default class MovementSystem implements BaseSystem {
 			Body.applyForce(body, body.position, { x: forceX, y: forceY });
 		}
 
-		ship.health -= 0.5;
+		ship.health -= 2;
 		if (!(ship instanceof NPCShip))
 			console.log(
 				`Body Pos ${ship.body.position.x}, ${ship.body.position.y}, Mirrored Pos: ${ship.x}, ${ship.y}.`

--- a/server/src/systems/movement-system.ts
+++ b/server/src/systems/movement-system.ts
@@ -474,12 +474,6 @@ export default class MovementSystem implements BaseSystem {
 			}
 			Body.applyForce(body, body.position, { x: forceX, y: forceY });
 		}
-
-		ship.health -= 2;
-		if (!(ship instanceof NPCShip))
-			console.log(
-				`Body Pos ${ship.body.position.x}, ${ship.body.position.y}, Mirrored Pos: ${ship.x}, ${ship.y}.`
-			);
 	}
 
 	updateCannon(cannon: Cannon, dt: number) {


### PR DESCRIPTION
Old method was just moving ships' centre of gravity, not the physics body on respawn. This fixes both the phasing through islands and jumping around issues.

Fixes #153 